### PR TITLE
Fix dependencies to avoid bad version of 'typer' lib

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ runs:
         python-version: "3.8"
 
     - name: install prefect
-      run: pip install 'prefect==2.8.5' 'pydantic>=1.10.0,<2.0.0' 'anyio<4'
+      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4'
       shell: bash
 
     - name: trigger prefect flow


### PR DESCRIPTION
Fixes this problem (confirmed in local testing):

```
  prefect cloud login --key "***" --workspace "dataopslandtech/landtech"
  prefect deployment run "mario_e2e_test/prod"
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.8.18/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.8.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.8.18/x64/lib
Authenticated with Prefect Cloud! Using workspace 'dataopslandtech/landtech'.
An exception occurred.
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/prefect/cli/_utilities.py", line 41, in wrapper
    return fn(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/prefect/utilities/asyncutils.py", line 230, in coroutine_wrapper
    return run_async_in_new_loop(async_fn, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/prefect/utilities/asyncutils.py", line 181, in run_async_in_new_loop
    return anyio.run(partial(__fn, *args, **kwargs))
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/anyio/_core/_eventloop.py", line 68, in run
    return asynclib.run(func, *args, **backend_options)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 204, in run
    return native_run(wrapper(), debug=debug)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/anyio/_backends/_asyncio.py", line 199, in wrapper
    return await func(*args)
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/prefect/cli/deployment.py", line 518, in run
    cli_params = _load_json_key_values(params, "parameter")
  File "/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/prefect/cli/deployment.py", line 1257, in _load_json_key_values
    for spec in cli_input:
TypeError: 'NoneType' object is not iterable
```