### PR TITLE
Cu 86947uz2v Add optional Prefect flow params input

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ required: true
 name: api_key
 description: "Prefect cloud api key, please provide a secret"
 required: true
+
+name: params:
+description: "Prefect flow parameters (optional)"
+required: false
+default: ''
 ```
 
 ## Example

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ runs:
       run: |
         prefect cloud login --key "${{ inputs.api_key }}" --workspace "${{ inputs.workspace_name }}"
         prefect deployment run "${{ inputs.deployment_name }}" \
-        -- params ${{ inputs.params }}
+        --params ${{ inputs.params }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ runs:
       run: |
         prefect cloud login --key "${{ inputs.api_key }}" --workspace "${{ inputs.workspace_name }}"
         prefect deployment run "${{ inputs.deployment_name }}" \
-        -- params ${{ inputs.api_key }}
+        -- params ${{ inputs.params }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,11 @@ inputs:
   api_key:
     description: "Prefect cloud api key, please provide a secret"
     required: true
+  
+  params:
+    description: "Prefect flow parameters (optional)"
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -29,5 +34,6 @@ runs:
     - name: trigger prefect flow
       run: |
         prefect cloud login --key "${{ inputs.api_key }}" --workspace "${{ inputs.workspace_name }}"
-        prefect deployment run "${{ inputs.deployment_name }}"
+        prefect deployment run "${{ inputs.deployment_name }}" \
+        -- params ${{ inputs.api_key }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         python-version: "3.8"
 
     - name: install prefect
-      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4' 'typer~=0.9.4'
+      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4' 'apprise<1.8.0' 'typer~=0.9.4'
       shell: bash
 
     - name: trigger prefect flow

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ runs:
       run: |
         prefect cloud login --key "${{ inputs.api_key }}" --workspace "${{ inputs.workspace_name }}"
         prefect deployment run "${{ inputs.deployment_name }}" \
-        --params ${{ inputs.params }}
+        --params '${{ inputs.params }}'
       shell: bash


### PR DESCRIPTION
# What

- add optional Prefect flow `params` input with empty default value 
- pin `apprise<1.8.0`

# Why
- **Why add optional `params` input?**
  - part of the `reusable-run-stored-procedure-changed-files` action [duplicates the code from this action](https://github.com/landtechnologies/data-hub/blob/e9925059b4cc23ac2f58999ff0eff5080e7b99dc/.github/workflows/reusable-run-stored-procedure-changed-files.yml#L53-L58) but needs to pass params to `prefect deployment run`
  - it makes sense to extend the functionality of this action to add `params` as an optional input while not breaking `mario-e2e-trigger` which also uses this action
  - see https://github.com/landtechnologies/data-hub/pull/4106 for more detail

- **Why pin apprise?**
  - see Slack thread on apprise dependency [here](https://landtech.slack.com/archives/C069UBVBF0E/p1715616347811349)
  - running `mario-e2e-trigger` on master branch [currently fails because of this](https://github.com/landtechnologies/data-hub/actions/runs/9298891295/job/25591660715)

# Testing

- implemented this branch in the `mario-e2e-trigger` action and triggered [here](https://github.com/landtechnologies/data-hub/actions/runs/9298484997)
- implemented this branch in the `reusable-run-stored-procedure-changed-files` action and triggered [deploy-postgres-procedures](https://github.com/landtechnologies/data-hub/actions/runs/9298304278)