### PR TITLE
Update Prefect + Python (remove other deps)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         python-version: "3.8"
 
     - name: install prefect
-      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4' 'apprise<1.8.0' 'typer~=0.9.4' 'griffe<1.0.0'
+      run: pip install 'prefect~=2.20.9' 'pydantic>=1.10.0,<2.0.0'
       shell: bash
 
     - name: trigger prefect flow

--- a/action.yml
+++ b/action.yml
@@ -28,7 +28,7 @@ runs:
         python-version: "3.8"
 
     - name: install prefect
-      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4' 'apprise<1.8.0' 'typer~=0.9.4'
+      run: pip install 'prefect~=2.8.7' 'pydantic>=1.10.0,<2.0.0' 'anyio<4' 'apprise<1.8.0' 'typer~=0.9.4' 'griffe<1.0.0'
       shell: bash
 
     - name: trigger prefect flow

--- a/action.yml
+++ b/action.yml
@@ -25,10 +25,10 @@ runs:
     - name: install python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.8"
+        python-version: "3.12"
 
     - name: install prefect
-      run: pip install 'prefect~=2.20.9' 'pydantic>=1.10.0,<2.0.0'
+      run: pip install 'prefect~=2.20.9'
       shell: bash
 
     - name: trigger prefect flow


### PR DESCRIPTION
## What
- Python updated from 3.8 to 3.12
- Prefect bumped from 2.8.x to the latest 2 version 2.20.x
- All other deps removed besides Prefect

## Why
High-level is that the Mario e2e test trigger uses this action and currently errors:
![image](https://github.com/user-attachments/assets/4263e1b5-940a-4332-bebf-685910adb1c1)

Most of the other deps were due to the fact Prefect 2.8 had issues with various deps (`anyio` `apprise` `typer`).
I also removed `pydantic` as I can't see how this is used in the GH action.

## Testing
Successful run on the Mario e2e trigger flow [here](https://github.com/landtechnologies/data-hub/actions/runs/11216433064/job/31175719232)
![image](https://github.com/user-attachments/assets/6d94cfbd-209b-45d7-b471-b636f194adbd)

Via pointing the action at this branch e.g.
```
      - name: trigger-prefect-flow
        uses: landtechnologies/action-prefect-flow-trigger@CU-869620awt-trigger-add-griffe
        with:
```

## Risks
This action is only used by [x2 Mario e2e actions](https://github.com/search?q=org%3Alandtechnologies%20trigger-prefect-flow&type=code), one of which has been tested. So this is low risk.